### PR TITLE
Fixing breaking change: Added build step to publish flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - "v*.*.*"
+      - 'v*.*.*'
 
 name: Build and Release
 
@@ -21,6 +21,9 @@ jobs:
 
       - name: Verify versions
         run: node --version && npm --version && node -p process.versions.v8
+
+      - name: Build package
+        run: npm run build
 
       - name: Release package
         run: npm publish --ignore-scripts


### PR DESCRIPTION
The current version doesn't allow imports like the following while it used to:
```ts
import { Crisp } from 'crisp-sdk-web'
```

This is because the package no longer includes a `dist` folder. 

This is because your new build workflow wasn't actually running the build script before publishing. This change includes a step running the build script before publishing which should fix the issue. 

Your documentation specifically shows importing like this, so this was likely a breaking change for many.

Merging this and deploying a new version would be appreciated as then my team can update to the latest version.