### PR TITLE
Cookie Expiration fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,7 @@ class Crisp {
     this.locale = options.locale;
     this.sessionMerge = options.sessionMerge;
     this.cookieDomain = options.cookieDomain;
+    this.cookieExpire = options.cookieExpire;
     this.lockFullview = options.lockFullview;
     this.lockMaximized = options.lockMaximized;
     this.safeMode = options.safeMode;


### PR DESCRIPTION
Fixed a missing Crisp.configure option causing the cookieExpire value not to be defined when Crisp is initialized

(fix was tested locally, seemed to work)