### PR TITLE
additional methods support

### DIFF
--- a/src/chat.ts
+++ b/src/chat.ts
@@ -8,19 +8,19 @@ export default class CrispChat {
   }
 
   show() {
-    this.parent.autoInjectIfNecessasy();
+    this.parent.autoInjectIfNecessary();
 
     window.$crisp.push(["do", "chat:show"]);
   }
 
   hide() {
-    this.parent.autoInjectIfNecessasy();
+    this.parent.autoInjectIfNecessary();
 
     window.$crisp.push(["do", "chat:hide"]);
   }
 
   open() {
-    this.parent.autoInjectIfNecessasy();
+    this.parent.autoInjectIfNecessary();
 
     window.$crisp.push(["do", "chat:open"]);
   }
@@ -29,6 +29,24 @@ export default class CrispChat {
     if (this.parent.isCrispInjected()) {
       window.$crisp.push(["do", "chat:close"]);
     }
+  }
+
+  setHelpdeskView() {
+    this.parent.createSingletonIfNecessary();
+
+    window.$crisp.push(["do", "helpdesk:search"]);
+  }
+
+  openHelpdeskArticle(locale: string, slug: string, title?: string, category?: string) {
+    this.parent.createSingletonIfNecessary();
+
+    window.$crisp.push(["do", "helpdesk:article:open", [locale, slug, title, category]]);
+  }
+
+  queryHelpdesk(query: string) {
+    this.parent.createSingletonIfNecessary();
+
+    window.$crisp.push(["do", "helpdesk:query", [query]]);
   }
 
   unreadCount(): number {
@@ -74,5 +92,12 @@ export default class CrispChat {
 
     window.$crisp.push(["off", "chat:closed"]);
     window.$crisp.push(["on", "chat:closed", callback]);
+  }
+
+  onHelpdeskQueried(callback: Function) {
+    this.parent.createSingletonIfNecessary();
+
+    window.$crisp.push(["off", "helpdesk:queried"]);
+    window.$crisp.push(["on", "helpdesk:queried", callback]);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,6 +272,13 @@ class Crisp {
     window.$crisp.push(["config", "show:operator:count", [enabled]]);
   }
 
+  onWebsiteAvailabilityChanged(callback: Function) {
+    this.createSingletonIfNecessary();
+
+    window.$crisp.push(["off", "website:availability:changed"]);
+    window.$crisp.push(["on", "website:availability:changed", callback]);
+  }
+
   createSingletonIfNecessary() {
     // Assigns $crisp singleton
     if (window.$crisp === undefined) {
@@ -279,7 +286,7 @@ class Crisp {
     }
   }
 
-  autoInjectIfNecessasy() {
+  autoInjectIfNecessary() {
     if (!this.isCrispInjected()) {
       this.load();
     }

--- a/src/message.ts
+++ b/src/message.ts
@@ -121,6 +121,18 @@ export default class CrispMessage {
     window.$crisp.push(["do", "message:read"]);
   }
 
+  startThread(name: String) {
+    this.parent.createSingletonIfNecessary();
+
+    window.$crisp.push(["do", "message:thread:start", [name]]);
+  }
+
+  endThread(name?: String) {
+    this.parent.createSingletonIfNecessary();
+    
+    window.$crisp.push(["do", "message:thread:end", [name]]);
+  }
+
   onMessageSent(callback: Function) {
     this.parent.createSingletonIfNecessary();
 
@@ -142,7 +154,7 @@ export default class CrispMessage {
     window.$crisp.push(["on", "message:compose:sent", callback]);
   }
 
-  onMessageComposeReceive(callback: Function) {
+  onMessageComposeReceived(callback: Function) {
     this.parent.createSingletonIfNecessary();
 
     window.$crisp.push(["off", "message:compose:received"]);


### PR DESCRIPTION
// corrections of existing functions

autoInjectIfNecessasy => autoInjectIfNecessary (reason: typo)
onMessageComposeReceive => onMessageComposeReceived (reason: consistency with the $crisp and npm equivalents and recent change on onChatClose => onChatClosed)


// Crisp wrapper support added for the following methods

* callbacks
Crisp.onWebsiteAvailabilityChanged for website:availability:changed
Crisp.chat.onHelpdeskQueried for helpdesk:queried

* actions
Crisp.chat.setHelpdeskView for helpdesk:search
Crisp.chat.openHelpdeskArticle for helpdesk:article:open
Crisp.chat.queryHelpdesk for helpdesk:query
Crisp.message.startThread for message:thread:start
Crisp.message.endThread for message:thread:end